### PR TITLE
Update pom to use selenium-server 2.40.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-server</artifactId>
-			<version>2.37.1</version>
+			<version>2.40.0</version>
 			<type>pom</type>
 		</dependency>
 


### PR DESCRIPTION
Updating pom dependency for selenium-server to the latest (2.40.0).

Fix for issue: https://github.com/FINRAOS/JTAF-ExtWebDriver/issues/35
