### PR TITLE
Fixed typo in Element.waitForElementPresent() exception message.

### DIFF
--- a/src/main/java/org/finra/jtaf/ewd/widget/element/Element.java
+++ b/src/main/java/org/finra/jtaf/ewd/widget/element/Element.java
@@ -292,7 +292,7 @@ public class Element implements IElement {
 				}
 			}, time);
 		} catch (WidgetTimeoutException e) {
-			throw new WidgetException("Error while waiting for element to be not present", locator, e);
+			throw new WidgetException("Error while waiting for element to be present", locator, e);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Ben Bunk <benbunk+github@gmail.com>
