### PR TITLE
Added download folder configuration for Chrome

### DIFF
--- a/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
@@ -430,12 +430,14 @@ public class DefaultSessionFactory implements SessionFactory {
                 }
                 
                 // for downloading with Chrome
-                HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
-                chromePrefs.put("profile.default_content_settings.popups", 0);
-                chromePrefs.put("download.default_directory", properties.getDownloadFolder());
-                ChromeOptions chromeOptions = new ChromeOptions();
-                chromeOptions.setExperimentalOption("prefs", chromePrefs);
-                desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+                if(properties.getDownloadFolder() != null) {
+                    HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+                    chromePrefs.put("profile.default_content_settings.popups", 0);
+                    chromePrefs.put("download.default_directory", properties.getDownloadFolder());
+                    ChromeOptions chromeOptions = new ChromeOptions();
+                    chromeOptions.setExperimentalOption("prefs", chromePrefs);
+                    desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+                }
 
                 wd = new ChromeDriver(desiredCapabilities);
             } else if (browser.equalsIgnoreCase("safari")) {

--- a/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
@@ -43,6 +43,7 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
@@ -427,6 +428,14 @@ public class DefaultSessionFactory implements SessionFactory {
                 if (webdriverChromeDriver != null) {
                     System.setProperty("webdriver.chrome.driver", webdriverChromeDriver);
                 }
+                
+                // for downloading with Chrome
+                HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+                chromePrefs.put("profile.default_content_settings.popups", 0);
+                chromePrefs.put("download.default_directory", properties.getDownloadFolder());
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.setExperimentalOption("prefs", chromePrefs);
+                desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
 
                 wd = new ChromeDriver(desiredCapabilities);
             } else if (browser.equalsIgnoreCase("safari")) {


### PR DESCRIPTION
In order to download files with Chrome the download.default_directory and profile.default_content_settings.popups must be set. This will set those properties based on what's in the ClientProperties.