### PR TITLE
Added tunnel-identifier capability to DefaultSessionFactory and Clien…

### DIFF
--- a/src/main/java/org/finra/jtaf/ewd/impl/ClientProperties.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/ClientProperties.java
@@ -94,6 +94,7 @@ public class ClientProperties {
     private final String gridPlatform;
     private final String gridProperties;
     private final String gridSauceFile;
+    private final String tunnelIdentifier;
 
     /**
      * Constructs a {@code ClientProperties} from the given file.
@@ -295,6 +296,7 @@ public class ClientProperties {
                 "Selenium Grid OS Platform name (e.g. 'Windows 7')");
         gridProperties = load("grid.properties", "record-screenshots=true",
                 "Space separated Selenium Grid properties (e.g. 'record-screenshots=true')");
+        tunnelIdentifier = load("tunnel.identifier", null, "sauce connect tunnel name");
     }
 
     /**
@@ -698,5 +700,9 @@ public class ClientProperties {
      */
     public URL getClient() {
         return client;
+    }
+
+    public String getTunnelIdentifier() {
+        return tunnelIdentifier;
     }
 }

--- a/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
@@ -33,6 +33,7 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 
+import com.google.common.base.Strings;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -245,8 +246,10 @@ public class DefaultSessionFactory implements SessionFactory {
             	
             }
             
-
-            
+            String tunnelIdentifier = properties.getTunnelIdentifier();
+            if(!Strings.isNullOrEmpty(tunnelIdentifier)) {
+                capabilities.setCapability("tunnel-identifier", tunnelIdentifier);
+            }
             
             // Set Proxy
             String proxyStr = properties.getProxy();


### PR DESCRIPTION
…tProperties

Summary of Changes:
* ClientProperties.java - Loaded tunnel.identifier property from the Client Properties file; null if not present
* DefaultSessionFactory.java - If the tunnelIdentifier is not null or empty, set the tunnel-identifier capability

This has been tested locally via an overridden DefaultSessionFactory and allows for SauceLabs to connect to a tunnel by name.

Not sure if/how we unit test these kinds of things. If there's something that should be done before this gets merged back, please let me know and I'll do what I can to update it.