### PR TITLE
Added support for Flash plugin in Chrome

### DIFF
--- a/src/main/java/org/finra/jtaf/ewd/impl/ClientProperties.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/ClientProperties.java
@@ -69,6 +69,8 @@ public class ClientProperties {
     private final String downloadFolder;
     private final String uploadFolder;
 
+    private final boolean flashEnabled;  // Chrome only?
+
     private final String maxAllowedSessions;
     private final String binaryPath;
     private final String webDriverIEDriver;
@@ -248,6 +250,8 @@ public class ClientProperties {
                     + "'",e);
         }
 
+
+
         tempFolderNameContainsList = load("tempFolderNameContainsList", null,
                 "Comma separated list of folders to clean with webDriver temp files");
 
@@ -289,6 +293,16 @@ public class ClientProperties {
             selectLastFrame = false;
         } else {
             selectLastFrame = true;
+        }
+
+        String enableFlash = load("flash.enabled", "false",
+                "Enable the Flash plugin. Property only works in Chrome for now."
+        );
+        if(enableFlash != null && (enableFlash.equalsIgnoreCase("true") || enableFlash.equalsIgnoreCase("yes")
+                || enableFlash.equalsIgnoreCase("on") || enableFlash.equalsIgnoreCase("1"))) {
+            flashEnabled = true;
+        } else {
+            flashEnabled = false;
         }
 
         gridSauceFile = load("grid.saucefile", null, "grid sauce file goes here") ;
@@ -383,9 +397,6 @@ public class ClientProperties {
             	highlightColorMap.put("get".toUpperCase(), load("highlight.get", "rgb(135, 206, 250)", "color for highlight element during finding"));
             if(!highlightColorMap.containsKey("put"))		
             	highlightColorMap.put("put".toUpperCase(), load("highlight.put", "rgb(152, 251, 152)", "color for highlight element during finding"));
-       
-        
-     
       }
 
       public String getHighlightColor(String colorMode){
@@ -724,4 +735,6 @@ public class ClientProperties {
 	public boolean shouldIgnoreSecurityDomains() {
 		return ignoreSecurityDomains;
 	}
+
+    public boolean shouldEnableFlash() { return flashEnabled; }
 }

--- a/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
@@ -441,16 +441,24 @@ public class DefaultSessionFactory implements SessionFactory {
                 if (webdriverChromeDriver != null) {
                     System.setProperty("webdriver.chrome.driver", webdriverChromeDriver);
                 }
-                
+
+                HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+
                 // for downloading with Chrome
                 if(properties.getDownloadFolder() != null) {
-                    HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
                     chromePrefs.put("profile.default_content_settings.popups", 0);
                     chromePrefs.put("download.default_directory", properties.getDownloadFolder());
-                    ChromeOptions chromeOptions = new ChromeOptions();
-                    chromeOptions.setExperimentalOption("prefs", chromePrefs);
-                    desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
                 }
+
+                if(properties.shouldEnableFlash()) {
+                    chromePrefs.put("profile.default_content_setting_values.plugins",1);
+                    chromePrefs.put("profile.content_settings.plugin_whitelist.adobe-flash-player",1);
+                    chromePrefs.put("profile.content_settings.exceptions.plugins.*,*.per_resource.adobe-flash-player",1);
+                }
+
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.setExperimentalOption("prefs", chromePrefs);
+                desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
 
                 wd = new ChromeDriver(desiredCapabilities);
             } else if (browser.equalsIgnoreCase("safari")) {

--- a/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
+++ b/src/main/java/org/finra/jtaf/ewd/impl/DefaultSessionFactory.java
@@ -363,6 +363,12 @@ public class DefaultSessionFactory implements SessionFactory {
         String browser = properties.getBrowser();
 
         if (properties.isUseGrid()) {
+			if (browser.equalsIgnoreCase("chrome")) {		
+				ChromeOptions chromeOptions = new ChromeOptions();
+				chromeOptions=setChromeOptions(properties);
+				
+				capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+			}
             RemoteWebDriver remoteWebDriver = new RemoteWebDriver(new URL(properties.getGridUrl()),
                     capabilities);
             remoteWebDriver.setFileDetector(new LocalFileDetector());
@@ -442,22 +448,9 @@ public class DefaultSessionFactory implements SessionFactory {
                     System.setProperty("webdriver.chrome.driver", webdriverChromeDriver);
                 }
 
-                HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+				ChromeOptions chromeOptions = new ChromeOptions();
+				chromeOptions=setChromeOptions(properties);
 
-                // for downloading with Chrome
-                if(properties.getDownloadFolder() != null) {
-                    chromePrefs.put("profile.default_content_settings.popups", 0);
-                    chromePrefs.put("download.default_directory", properties.getDownloadFolder());
-                }
-
-                if(properties.shouldEnableFlash()) {
-                    chromePrefs.put("profile.default_content_setting_values.plugins",1);
-                    chromePrefs.put("profile.content_settings.plugin_whitelist.adobe-flash-player",1);
-                    chromePrefs.put("profile.content_settings.exceptions.plugins.*,*.per_resource.adobe-flash-player",1);
-                }
-
-                ChromeOptions chromeOptions = new ChromeOptions();
-                chromeOptions.setExperimentalOption("prefs", chromePrefs);
                 desiredCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
 
                 wd = new ChromeDriver(desiredCapabilities);
@@ -487,6 +480,27 @@ public class DefaultSessionFactory implements SessionFactory {
 
         return wd;
     }
+
+	private ChromeOptions setChromeOptions(ClientProperties properties){
+		HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+                
+		// for downloading with Chrome
+		if(properties.getDownloadFolder() != null) {
+			chromePrefs.put("profile.default_content_settings.popups", 0);
+			chromePrefs.put("download.default_directory", properties.getDownloadFolder());
+		}
+		
+		if(properties.shouldEnableFlash()) {  
+			chromePrefs.put("profile.default_content_setting_values.plugins",1);  
+			chromePrefs.put("profile.content_settings.plugin_whitelist.adobe-flash-player",1);  
+			chromePrefs.put("profile.content_settings.exceptions.plugins.*,*.per_resource.adobe-flash-player",1);  
+		}
+
+		ChromeOptions chromeOptions = new ChromeOptions();
+		chromeOptions.setExperimentalOption("prefs", chromePrefs);
+		
+		return chromeOptions;
+	}
 
     /*
      * (non-Javadoc)


### PR DESCRIPTION
By default, the Chrome webdriver disables all plugins. This code allows
you to enable the Flash plugin if you desire, *assuming it is already
installed*.

To enable the Flash plugin, add the following line to your
chrome.properties file:

flash.enabled=true

This is a cherry-pick of commit d861c7c4238ac9f052d0c1383fce61b6f0d59b5a
.